### PR TITLE
Refine Wi-Fi control backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,23 @@
 A system designed for remote control and configuration of microcontrollers. It consists of two main components: a microcontroller and a web interface. 
 
 The microcontroller executes server instructions and interacts with connected components, while the web interface allows users to configure settings, manage firmware, and design workflows through a visual interface. This solution provides flexibility and simplicity for managing electronic systems remotely.
+
+## Wi-Fi communication
+
+The backend communicates with the microcontroller over the local network. On startup you specify the device IP when uploading the program. Each algorithm step is sent to the microcontroller as an HTTP request, so both devices must be connected to the same Wi‑Fi network.
+
+## Running the backend and frontend
+
+1. Install Python dependencies:
+   ```bash
+   pip install -r backend/requirements.txt
+   ```
+2. From the repository root, run the server:
+   ```bash
+   python backend/src/server.py
+   ```
+   The server will automatically start the React development server and provide a link to `http://localhost:3000`.
+
+3. Send the microcontroller configuration and algorithm:
+   - `POST /program` – JSON containing `config` (with the device IP) and `algorithm`.
+   - `POST /run` – execute the uploaded algorithm by sending commands over Wi‑Fi.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+Flask
+requests

--- a/backend/src/server.py
+++ b/backend/src/server.py
@@ -1,0 +1,74 @@
+from flask import Flask, request, jsonify
+import subprocess
+import os
+import threading
+import requests
+import time
+
+app = Flask(__name__)
+
+# Path to the frontend directory
+FRONTEND_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', '..', 'frontend')
+
+# Simple microcontroller client communicating over HTTP
+class Microcontroller:
+    def __init__(self, host: str = '192.168.1.50'):
+        # Base address of the device on the local network
+        self.base_url = f'http://{host}'
+
+    def send_command(self, pin: int, value: int, delay: float = 0):
+        payload = {'pin': pin, 'value': value, 'delay': delay}
+        try:
+            requests.post(f'{self.base_url}/command', json=payload, timeout=2)
+        except requests.RequestException as exc:
+            # In this simple example we just log errors
+            print('Failed to send command:', exc)
+
+microcontroller = Microcontroller()
+
+# In-memory algorithm storage
+current_algorithm = []
+
+@app.route('/program', methods=['POST'])
+def program():
+    """Receive microcontroller config and algorithm."""
+    global current_algorithm, microcontroller
+    data = request.get_json(force=True)
+
+    if isinstance(data, dict):
+        config = data.get('config') or {}
+        algo = data.get('algorithm')
+    else:
+        config = {}
+        algo = data
+
+    host = config.get('host')
+    if host:
+        microcontroller = Microcontroller(host)
+
+    if algo is not None:
+        current_algorithm = algo
+
+    return jsonify({'status': 'loaded'})
+
+@app.route('/run', methods=['POST'])
+def run_algorithm():
+    for step in current_algorithm:
+        pin = step.get('pin')
+        value = step.get('value')
+        delay = step.get('delay', 0)
+        microcontroller.send_command(pin, value, delay)
+        time.sleep(delay)
+    return jsonify({'status': 'completed'})
+
+@app.route('/')
+def index():
+    return jsonify({'message': 'Server running', 'frontend': 'http://localhost:3000'})
+
+# Helper to start react dev server
+def start_react():
+    subprocess.Popen(['npm', 'start'], cwd=FRONTEND_PATH)
+
+if __name__ == '__main__':
+    threading.Thread(target=start_react, daemon=True).start()
+    app.run(debug=True)


### PR DESCRIPTION
## Summary
- remove pyserial and implement HTTP microcontroller client
- add `/program` and `/run` endpoints
- document Wi-Fi connection and updated API
- drop `pyserial` and add `requests` dependency

## Testing
- `python -m py_compile backend/src/server.py`


------
https://chatgpt.com/codex/tasks/task_e_683f41389b90832399e97aa5e510097c