### PR TITLE
Add simple backend server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,21 @@
 A system designed for remote control and configuration of microcontrollers. It consists of two main components: a microcontroller and a web interface. 
 
 The microcontroller executes server instructions and interacts with connected components, while the web interface allows users to configure settings, manage firmware, and design workflows through a visual interface. This solution provides flexibility and simplicity for managing electronic systems remotely.
+
+## Backend server
+
+To receive configuration from the frontend, start the provided Python server:
+
+```bash
+python backend/server.py --ip 127.0.0.1 --port 8000
+```
+
+The frontend can send the configuration JSON to `http://127.0.0.1:8000/configuration`.
+The server prints the received data to the console. Example using `curl`:
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"foo": "bar"}' http://127.0.0.1:8000/configuration
+```
+
+

--- a/backend/server.py
+++ b/backend/server.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Simple backend server accepting configuration via POST /configuration."""
+import json
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class ConfigHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        if self.path != '/configuration':
+            self.send_error(404, 'Not Found')
+            return
+        content_length = int(self.headers.get('Content-Length', 0))
+        raw = self.rfile.read(content_length)
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            self.send_error(400, 'Invalid JSON')
+            return
+        print('Received configuration:', data, flush=True)
+        self.send_response(200)
+        self.send_header('Content-Type', 'application/json')
+        self.end_headers()
+        self.wfile.write(b'{"status": "received"}')
+
+
+def run_server(ip: str = '127.0.0.1', port: int = 8000) -> None:
+    """Run HTTP server on provided IP and port."""
+    httpd = HTTPServer((ip, port), ConfigHandler)
+    print(f'Server listening on {ip}:{port}', flush=True)
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        httpd.server_close()
+
+
+if __name__ == '__main__':
+    import argparse
+
+    parser = argparse.ArgumentParser(description='Simple backend configuration server')
+    parser.add_argument('--ip', default='127.0.0.1', help='IP address to bind to')
+    parser.add_argument('--port', type=int, default=8000, help='Port to bind to')
+    args = parser.parse_args()
+    run_server(args.ip, args.port)


### PR DESCRIPTION
## Summary
- implement a lightweight Python HTTP server handling `/configuration`
- remove unused connect script and config file
- show example `curl` invocation in the README

## Testing
- `python -m py_compile backend/server.py`
- `python backend/server.py --ip 127.0.0.1 --port 8000 >/tmp/server.log 2>&1 &`
- `curl -X POST -H 'Content-Type: application/json' -d '{"foo": "bar"}' http://127.0.0.1:8000/configuration >/tmp/curl.log 2>&1`
- `cat /tmp/server.log`
- `cat /tmp/curl.log`


------
https://chatgpt.com/codex/tasks/task_e_68461be3f99083238da2f45d6e69d165